### PR TITLE
Update IdentifierForm.tsx

### DIFF
--- a/src/screens/login-id/components/IdentifierForm.tsx
+++ b/src/screens/login-id/components/IdentifierForm.tsx
@@ -25,7 +25,7 @@ const IdentifierForm: React.FC = () => {
   // Handle text fallbacks in component
   const buttonText = texts?.buttonText || "Continue";
   const loadingText = "Processing..."; // Default fallback
-  const captchaLabel = texts?.captchaCodePlaceholder.concat("*") || "CAPTCHA*";
+  const captchaLabel = texts?.captchaCodePlaceholder?.concat("*") || "CAPTCHA*";
   const captchaImageAlt = "CAPTCHA challenge"; // Default fallback
   const forgotPasswordText = texts?.forgotPasswordText || "Forgot Password?";
 


### PR DESCRIPTION
Bug fix on Identifier form, if context_configuration for `screen.texts` is not passed during configuration of acul screens.