### PR TITLE
docs: update the --settings flag command in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ npm install -g @auth0/auth0-cli
 auth0 login
 
 # Configure ACUL with settings file
-auth0 ul customize --rendering-mode advanced --prompt login-id --screen login-id --settings ./settings.json
+auth0 ul customize --rendering-mode advanced --prompt login-id --screen login-id --settings-file ./settings.json
 ```
 
 **About settings.json:** This file contains the same ACUL payload configuration as shown in the [Build Structure](#build-structure) section. It defines how Auth0 should load your custom screen assets, including CSS files, JavaScript bundles, and context configuration. The settings.json file structure is identical to the payload you'd use when configuring ACUL programmatically.


### PR DESCRIPTION
## Description

Brief description of the changes and the problem they solve.

Documentation change the `--settings` flag used in the command to update the screen is wrong. see docs https://auth0.github.io/auth0-cli/auth0_universal-login_customize.html 


## Changes

- [x] List the specific changes made
- [ ] Include any breaking changes
- [ ] Note any new dependencies or configuration updates

changes are in README.md file

## Testing

- [ ] Tests pass locally
- [ ] New tests added for new functionality
- [ ] Manual testing completed
- [x] No breaking changes to existing functionality

## Checklist

- [x] Code follows the project's style guidelines
- [ ] Self-review of the code completed
- [ ] Code is commented where necessary
- [ ] Documentation updated if needed
- [ ] Changes generate no new warnings
