### PR TITLE
fix: MFA Enrollment QR Screen Integration with continue method of SDK

### DIFF
--- a/react/src/__mocks__/@auth0/auth0-acul-react/mfa-push-enrollment-qr.ts
+++ b/react/src/__mocks__/@auth0/auth0-acul-react/mfa-push-enrollment-qr.ts
@@ -11,6 +11,7 @@ import type {
  * This provides a single, type-safe object to control in our tests.
  */
 export interface MockMfaPushEnrollmentQRInstance {
+  continue: jest.Mock;
   pickAuthenticator: jest.Mock;
   screen: ScreenMembersOnMfaPushEnrollmentQr;
   transaction: TransactionMembers;
@@ -24,6 +25,7 @@ export interface MockMfaPushEnrollmentQRInstance {
  */
 export const createMockMfaPushEnrollmentQRInstance =
   (): MockMfaPushEnrollmentQRInstance => ({
+    continue: jest.fn(),
     pickAuthenticator: jest.fn(),
     screen: {
       name: "mfa-push-enrollment-qr",
@@ -98,6 +100,7 @@ export const pickAuthenticator =
 
 export const useMfaPushEnrollmentQr = jest.fn(() => ({
   screen: mockMfaPushEnrollmentQRInstance.screen,
+  continue: mockMfaPushEnrollmentQRInstance.continue,
   pickAuthenticator: mockMfaPushEnrollmentQRInstance.pickAuthenticator,
 }));
 

--- a/react/src/screens/mfa-push-enrollment-qr/components/MfaPushEnrollmentQRForm.tsx
+++ b/react/src/screens/mfa-push-enrollment-qr/components/MfaPushEnrollmentQRForm.tsx
@@ -14,8 +14,14 @@ import { ULThemeAlert, ULThemeAlertTitle } from "@/components/ULThemeError";
 import { useMfaPushEnrollmentQRManager } from "../hooks/useMfaPushEnrollmentQRManager";
 
 function MfaPushEnrollmentQRForm() {
-  const { data, texts, locales, enrolledFactors, handlePickAuthenticator } =
-    useMfaPushEnrollmentQRManager();
+  const {
+    data,
+    texts,
+    locales,
+    enrolledFactors,
+    handlePickAuthenticator,
+    handleContinueMfaPushEnrollmentQR,
+  } = useMfaPushEnrollmentQRManager();
 
   // Initialize the form using react-hook-form
   const form = useForm<CustomOptions>({});
@@ -40,6 +46,9 @@ function MfaPushEnrollmentQRForm() {
   // Automatically start polling when the page loads
   const { startPolling, stopPolling } = useMfaPolling({
     intervalMs: 3000,
+    onCompleted: () => {
+      handleContinueMfaPushEnrollmentQR();
+    },
     onError: (error: unknown) =>
       console.error("Push Enrollment Polling error:", error),
   });

--- a/react/src/screens/mfa-push-enrollment-qr/hooks/useMfaPushEnrollmentQRManager.ts
+++ b/react/src/screens/mfa-push-enrollment-qr/hooks/useMfaPushEnrollmentQRManager.ts
@@ -6,6 +6,7 @@ import {
 import {
   CustomOptions,
   MfaPushEnrollmentQrMembers,
+  MfaPushEnrollmentQrWithRememberOptions,
   ScreenMembersOnMfaPushEnrollmentQr,
   UserMembers,
 } from "@auth0/auth0-acul-react/types";
@@ -22,6 +23,15 @@ export const useMfaPushEnrollmentQRManager = () => {
   const { texts, data } = screen;
   const { enrolledFactors } = userInfo || {};
 
+  const handleContinueMfaPushEnrollmentQR = async (
+    payload?: MfaPushEnrollmentQrWithRememberOptions
+  ): Promise<void> => {
+    await executeSafely(
+      `Continue MFA Push Enrollment QR with options: ${JSON.stringify(payload)}`,
+      () => mfaPushEnrollmentQR.continue(payload)
+    );
+  };
+
   const handlePickAuthenticator = async (
     payload?: CustomOptions
   ): Promise<void> => {
@@ -37,6 +47,7 @@ export const useMfaPushEnrollmentQRManager = () => {
     enrolledFactors,
     mfaPushEnrollmentQR,
     handlePickAuthenticator,
+    handleContinueMfaPushEnrollmentQR,
     texts: (texts || {}) as ScreenMembersOnMfaPushEnrollmentQr["texts"],
   };
 };


### PR DESCRIPTION
## Description

**This PR integrates `mfa-push-enrollment-qr` screen with continue method which gets invoked once user completes qr code registration via Auth0 Guardian or similar authenticator application.**

## Changes

Changes made on below files:
1: **MfaPushEnrollmentQRForm**(react/src/screens/mfa-push-enrollment-qr/components/MfaPushEnrollmentQRForm.tsx) for incorporating handle continue hook call
2. **useMfaPushEnrollmentQRManager**(react/src/screens/mfa-push-enrollment-qr/hooks/useMfaPushEnrollmentQRManager.ts) for adding a new wrapper over continue sdk method
3. **createMockMfaPushEnrollmentQRInstance**(react/src/__mocks__/@auth0/auth0-acul-react/mfa-push-enrollment-qr.ts) for adding mocks for relevant changes

- [x] List the specific changes made
- [x] Include any breaking changes
- [x] Note any new dependencies or configuration updates

## Testing

Screen Tests:
<img width="1176" height="818" alt="image" src="https://github.com/user-attachments/assets/7c8d782a-9e53-49ba-9384-53204309d44c" />

<img width="1085" height="758" alt="image" src="https://github.com/user-attachments/assets/8f8e0906-9821-49ba-9268-017fe166fca6" />


<img width="1112" height="775" alt="image" src="https://github.com/user-attachments/assets/dd45e7d6-fe2c-4a5b-9f64-ffc00ff47826" />


**Unit Tests:**
<img width="640" height="294" alt="image" src="https://github.com/user-attachments/assets/0b4e6179-0682-4904-8f23-4aabb5109eb0" />


<img width="665" height="253" alt="image" src="https://github.com/user-attachments/assets/92d717d1-e3f1-494b-9c3d-224d430e96cd" />


**Build Screenshot:**
<img width="886" height="864" alt="image" src="https://github.com/user-attachments/assets/28447532-c1ac-4746-ae2b-a1aa21eaead9" />

**Lint Test:**
<img width="728" height="605" alt="image" src="https://github.com/user-attachments/assets/2bc89e67-0ad9-4129-89d1-cad862b347a5" />

**Manifest Validate:**
<img width="527" height="218" alt="image" src="https://github.com/user-attachments/assets/d6cc5592-3807-4517-99b4-b18ef80320ed" />


- [x] Tests pass locally
- [x] New tests added for new functionality
- [x] Manual testing completed
- [x] No breaking changes to existing functionality

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the code completed
- [x] Code is commented where necessary
- [x] Documentation updated if needed
- [x] Changes generate no new warnings
