### PR TITLE
fix(security): run npm ci with --ignore-scripts

### DIFF
--- a/.github/workflows/react-ci.yml
+++ b/.github/workflows/react-ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: react
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Lint check
         working-directory: react


### PR DESCRIPTION
This would avoid malicious scripts in vulnerable packages to be executed on CI